### PR TITLE
Add k-hot support, SWAP mixer, benchmarks, and tests

### DIFF
--- a/qokit/fur/c/csim/src/makefile
+++ b/qokit/fur/c/csim/src/makefile
@@ -1,14 +1,27 @@
 # ─────────────────────────  build options  ──────────────────────────────
 CC      ?= gcc
 CFLAGS  = -fopenmp -fPIC -Wall
-LDFLAGS = -fopenmp -shared
 TARGET_DIR := ..
 SRCS   := $(wildcard *.c)
 OBJS   := $(SRCS:.c=.o)
-TARGET := $(TARGET_DIR)/libcsim.so
+
+# Detect platform
+UNAME_S := $(shell uname -s)
+
+# Default values (Linux)
+LDFLAGS = -fopenmp -shared
+TARGET = $(TARGET_DIR)/libcsim.so
+
+# macOS-specific settings
+ifeq ($(UNAME_S),Darwin)
+    LDFLAGS = -fopenmp -dynamiclib \
+              -Wl,-syslibroot,$(shell xcrun --show-sdk-path) \
+              -install_name @rpath/libcsim.dylib
+    TARGET = $(TARGET_DIR)/libcsim.dylib
+endif
 
 # Linux-only version script
-ifeq ($(shell uname),Linux)
+ifeq ($(UNAME_S),Linux)
     LDFLAGS += -Wl,--version-script=libcsim.map
 endif
 
@@ -17,6 +30,10 @@ INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 # ─────────────────────────  build rules  ────────────────────────────────
 all: $(TARGET)
+ifeq ($(UNAME_S),Darwin)
+	# Copy .dylib to .so for Python compatibility
+	cp -f $(TARGET_DIR)/libcsim.dylib $(TARGET_DIR)/libcsim.so
+endif
 
 $(TARGET): $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) -o $@
@@ -25,4 +42,4 @@ $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $(INC_FLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJS) $(TARGET)
+	rm -f $(OBJS) $(TARGET_DIR)/libcsim.so $(TARGET_DIR)/libcsim.dylib

--- a/tests/test_khot_swap_mixer.py
+++ b/tests/test_khot_swap_mixer.py
@@ -1,0 +1,48 @@
+###############################################################################
+# // SPDX-License-Identifier: Apache-2.0
+# // Copyright : JP Morgan Chase & Co
+###############################################################################
+
+import numpy as np
+import pytest
+
+from qokit.qaoa_objective import get_qaoa_objective
+
+@pytest.mark.parametrize("mixer,expected_khot", [
+    ("x", None),
+    ("xy", 2),
+    ("swap", 2)
+])
+def test_khot_flag_for_mixers(mixer, expected_khot):
+    N = 4
+    K = 2
+    p = 1
+
+    terms = [
+        (+1.0, [0, 1]),
+        (-0.5, [2, 3])
+    ]
+
+    if expected_khot is None:
+        f = get_qaoa_objective(
+            N=N,
+            terms=terms,
+            mixer=mixer,
+            k_hot=None
+        )
+    else:
+        f = get_qaoa_objective(
+            N=N,
+            terms=terms,
+            mixer=mixer,
+            k_hot=K
+        )
+    
+    theta = np.zeros(2 * p)
+    val = f(theta)
+
+    # Check that the function returns a float (runs without error)
+    assert isinstance(val, float)
+
+    # Print confirmation for debug
+    print(f"Mixer={mixer} ran successfully with k_hot={expected_khot}")


### PR DESCRIPTION
## Summary
Add k-hot initial state support to restrict QAOA to feasible subspaces

Implements a new SWAP mixer for hamming weight preserving mixing

Integrates both into get_qaoa_objective

### Includes:

- add two new functions in get_qaoa_objective method for adding a new key `k_hot` and add swap as a new mixer
- new tests verifying k-hot logic and SWAP integration
- changes in makefile to support multi platform 